### PR TITLE
Corrected Namespace to match project

### DIFF
--- a/Cake.SemVer.Tests/Cake.SemVer.Tests.csproj
+++ b/Cake.SemVer.Tests/Cake.SemVer.Tests.csproj
@@ -5,8 +5,8 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{4892D81A-AD1A-442B-B456-B1BF6754C75B}</ProjectGuid>
     <OutputType>Library</OutputType>
-    <RootNamespace>Cake.FileHelpers.Tests</RootNamespace>
-    <AssemblyName>Cake.FileHelpers.Tests</AssemblyName>
+    <RootNamespace>Cake.SemVer.Tests</RootNamespace>
+    <AssemblyName>Cake.SemVer.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Cake.SemVer/Namespaces.cs
+++ b/Cake.SemVer/Namespaces.cs
@@ -1,9 +1,9 @@
 ﻿using System.Runtime.CompilerServices;
 
-namespace Cake.FileHelpers
+namespace Cake.SemVer
 {
     /// <summary>
-    /// This namespace contain types 
+    /// This namespace contain types
     /// representing data used for Semantic Versioning.
     /// </summary>
     [CompilerGenerated]

--- a/Cake.SemVer/Properties/AssemblyInfo.cs
+++ b/Cake.SemVer/Properties/AssemblyInfo.cs
@@ -4,7 +4,7 @@ using System.Runtime.CompilerServices;
 // Information about this assembly is defined by the following attributes.
 // Change them to the values specific to your project.
 
-[assembly: AssemblyTitle ("Cake.FileHelpers")]
+[assembly: AssemblyTitle ("Cake.SemVer")]
 [assembly: AssemblyDescription ("")]
 [assembly: AssemblyConfiguration ("")]
 [assembly: AssemblyCompany ("")]


### PR DESCRIPTION
@Redth noticed that this was causing a problem with pulling the documentation into Cake Website.

Once merged in, any chance you can re-publish the NuGet package?  Thanks!
