### PR TITLE
 Upgrade to netstandard2.0 and Cake 0.26.1

### DIFF
--- a/src/Cake.SemVer.Tests/Cake.SemVer.Tests.csproj
+++ b/src/Cake.SemVer.Tests/Cake.SemVer.Tests.csproj
@@ -1,16 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="0.22.0" />
-    <PackageReference Include="Cake.Testing" Version="0.22.0" />
+    <PackageReference Include="Cake.Core" Version="0.26.1" />
+    <PackageReference Include="Cake.Testing" Version="0.26.1" />
     <PackageReference Include="semver" version="2.0.4" />
-    <PackageReference Include="xunit" Version="2.3.0-beta5-build3769" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta5-build3769" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Cake.SemVer/Cake.SemVer.csproj
+++ b/src/Cake.SemVer/Cake.SemVer.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.6;net46</TargetFrameworks>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.6' ">1.6.1</NetStandardImplicitPackageVersion>
+    <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
+    <NetStandardImplicitPackageVersion>2.0.0</NetStandardImplicitPackageVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
@@ -20,8 +20,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="0.22.0" />
-    <PackageReference Include="Cake.Common" Version="0.22.0" />
+    <PackageReference Include="Cake.Core" Version="0.26.1" />
+    <PackageReference Include="Cake.Common" Version="0.26.1" />
     <PackageReference Include="semver" Version="2.0.4" />
   </ItemGroup>
 

--- a/src/Cake.SemVer/SemVer.cs
+++ b/src/Cake.SemVer/SemVer.cs
@@ -10,7 +10,7 @@ namespace Cake.SemVer
     ///  Here is what including Cake.SemVer in your script should look like:
     /// <code>
     /// #addin package:?Cake.SemVer
-    /// #addin package:?semver&mp;version=2.0.4
+    /// #addin package:?semver&amp;version=2.0.4
     /// </code>
     /// </para>
     /// </summary>


### PR DESCRIPTION
The latest Cake version (0.26.1) complains about the version of Cake.SemVer being to old.

I have verified only using the unit tests and by running the current Cake.SemVer on 0.26.1 with "--settings_skipverification=true". If you have additional tests you usually perform please let me know how.

Many thanks in advance.

